### PR TITLE
Replace es6-collections with weakmap-polyfill - fix #118

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,8 +46,8 @@
     "postMessage"
   ],
   "dependencies": {
-    "es6-collections": "0.5.6",
-    "native-promise-only": "0.8.1"
+    "native-promise-only": "0.8.1",
+    "weakmap-polyfill": "2.0.0"
   },
   "devDependencies": {
     "@vimeo/eslint-config-player": "^4.0.1",

--- a/src/player.js
+++ b/src/player.js
@@ -1,6 +1,6 @@
 import './lib/compatibility-check';
 
-import 'es6-collections';
+import 'weakmap-polyfill';
 import Promise from 'native-promise-only';
 
 import { storeCallback, getCallbacks, removeCallback, swapCallbacks } from './lib/callbacks';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1463,10 +1463,6 @@ es5-ext@^0.10.14, es5-ext@^0.10.9, es5-ext@~0.10.14:
     es6-iterator "2"
     es6-symbol "~3.1"
 
-es6-collections@0.5.6:
-  version "0.5.6"
-  resolved "https://registry.yarnpkg.com/es6-collections/-/es6-collections-0.5.6.tgz#5552e800ad12c1820cda2bd4a79ae7dbb03d89a2"
-
 es6-error@^4.0.1, es6-error@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/es6-error/-/es6-error-4.0.2.tgz#eec5c726eacef51b7f6b73c20db6e1b13b069c98"
@@ -4200,6 +4196,10 @@ verror@1.10.0:
 vlq@^0.2.1:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/vlq/-/vlq-0.2.2.tgz#e316d5257b40b86bb43cb8d5fea5d7f54d6b0ca1"
+
+weakmap-polyfill@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/weakmap-polyfill/-/weakmap-polyfill-2.0.0.tgz#8f28f935e3853896ad40747e5258db578d9dc8de"
 
 webidl-conversions@^3.0.0:
   version "3.0.1"


### PR DESCRIPTION
Attempt to fix the stack overflow issue reported there

<!--
Please make sure to read our contributing guidelines first. Please try to limit the scope, provide a general description of the changes, and remember, it’s up to you to convince us to merge it.

If this fixes an open issue, link to it in the following way: `Fixes #321`.

New features and bug fixes should come with tests.
-->

Fixes #.
